### PR TITLE
Fix type issues in 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.0+1
+
+* Fix analysis errors caused via missing `/*<E>*/` syntax in `0.15.0`
+
 ## 0.15.0
 
 * Added the `Differ` interface, as well as `EqualityDiffer`

--- a/lib/src/differs/list_differ.dart
+++ b/lib/src/differs/list_differ.dart
@@ -14,7 +14,7 @@ part of observable.src.differs;
 class ListDiffer<E> implements Differ<List<E>> {
   final Equality<E> _equality;
 
-  const ListDiffer([this._equality = const DefaultEquality<E>()]);
+  const ListDiffer([this._equality = const DefaultEquality()]);
 
   @override
   List<ListChangeRecord<E>> diff(List<E> e1, List<E> e2) {
@@ -296,7 +296,7 @@ List<ListChangeRecord/*<E>*/ > _calcSplices/*<E>*/(
     }
   }
   if (hasSplice()) {
-    splices.add(new ListChangeRecord<E>(
+    splices.add(new ListChangeRecord/*<E>*/(
       current,
       spliceIndex,
       removed: spliceRemovals,
@@ -331,7 +331,7 @@ void _mergeSplices/*<E>*/(
   // - then continues and updates the subsequent splices with any offset diff.
   for (var i = 0; i < splices.length; i++) {
     var current = splices[i];
-    current = splices[i] = new ListChangeRecord<E>(
+    current = splices[i] = new ListChangeRecord/*<E>*/(
       current.object,
       current.index + insertionOffset,
       removed: current.removed,
@@ -395,7 +395,7 @@ void _mergeSplices/*<E>*/(
       );
       i++;
       final offset = spliceAdded - spliceRemoved.length;
-      current = splices[i] = new ListChangeRecord<E>(
+      current = splices[i] = new ListChangeRecord/*<E>*/(
         current.object,
         current.index + offset,
         removed: current.removed,

--- a/lib/src/observable_list.dart
+++ b/lib/src/observable_list.dart
@@ -311,7 +311,7 @@ class ObservableList<E> extends ListBase<E> with Observable {
     List/*<E>*/ oldValue,
     List/*<E>*/ newValue,
   ) {
-    return const ListDiffer<E>().diff(oldValue, newValue);
+    return const ListDiffer/*<E>*/().diff(oldValue, newValue);
   }
 
   /// Updates the [previous] list using the [changeRecords]. For added items,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.15.0
+version: 0.15.0+1
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
The internal analyzer caught more exceptions not shown to me in `0.15.0`

(I've filed an internal issue and will validate more closely going forwards)

## 0.15.0+1

* Fix analysis errors caused via missing `/*<E>*/` syntax in `0.15.0`