### PR TITLE
Revert PropertyChangeMixin, does not compile in dart2js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.0+1
+
+* Revert `PropertyChangeMixin`, which does not work in dart2js
+
 ## 0.17.0
 
 This is a larger change with a goal of no runtime changes for current

--- a/lib/src/change_notifier.dart
+++ b/lib/src/change_notifier.dart
@@ -105,11 +105,15 @@ class ChangeNotifier<C extends ChangeRecord> implements Observable<C> {
   }
 }
 
-/// Implements [notifyPropertyChange] for classes that need support.
+/// Supplies property `changes` and various hooks to implement [Observable].
 ///
-/// Will be folded entirely into [PropertyChangeNotifier] in the future.
-@Deprecated('Exists to make migrations off Observable easier')
-abstract class PropertyChangeMixin implements ChangeNotifier {
+/// May use `notifyChange` or `notifyPropertyChange` to queue a property change
+/// record; they are asynchronously delivered at the end of the VM turn.
+///
+/// [PropertyChangeNotifier] may be extended or used as a delegate. To use as
+/// a mixin, instead use with [PropertyChangeMixin]:
+///     with ChangeNotifier<PropertyChangeRecord>, PropertyChangeMixin
+class PropertyChangeNotifier extends ChangeNotifier<PropertyChangeRecord> {
   @override
   /*=T*/ notifyPropertyChange/*<T>*/(
     Symbol field,
@@ -131,14 +135,3 @@ abstract class PropertyChangeMixin implements ChangeNotifier {
     return newValue;
   }
 }
-
-/// Supplies property `changes` and various hooks to implement [Observable].
-///
-/// May use `notifyChange` or `notifyPropertyChange` to queue a property change
-/// record; they are asynchronously delivered at the end of the VM turn.
-///
-/// [PropertyChangeNotifier] may be extended or used as a delegate. To use as
-/// a mixin, instead use with [PropertyChangeMixin]:
-///     with ChangeNotifier<PropertyChangeRecord>, PropertyChangeMixin
-class PropertyChangeNotifier = ChangeNotifier<PropertyChangeRecord>
-    with PropertyChangeMixin;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.17.0
+version: 0.17.0+1
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
Not legal to have the same interface both typed and untyped.

I need to get this in before landing 0.17.0 internally.

## 0.17.0+1

* Revert `PropertyChangeMixin`, which does not work in dart2js