### PR TITLE
Bug fix on Observable.notifyChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.1
+
+* Bug fix: Do not throw when `Observable<T>.notifyChange` is used
+
 ## 0.18.0
 
 * Refactor and deprecate `ObservableList`-specific API

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -22,7 +22,7 @@ abstract class Observable<C extends ChangeRecord> {
   final ChangeNotifier<C> _delegate = new ChangeNotifier<C>();
 
   // Whether Observable was not given a type.
-  final bool _supportsPropertyChanges = C is PropertyChangeRecord;
+  final bool _supportsPropertyChanges = PropertyChangeRecord is C;
 
   /// Emits a list of changes when the state of the object changes.
   ///

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -90,8 +90,6 @@ abstract class Observable<C extends ChangeRecord> {
             newValue,
           ) as C,
         );
-      } else {
-        throw new UnsupportedError('Generic typed Observable does not support');
       }
     }
     return newValue;

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -22,7 +22,7 @@ abstract class Observable<C extends ChangeRecord> {
   final ChangeNotifier<C> _delegate = new ChangeNotifier<C>();
 
   // Whether Observable was not given a type.
-  final bool _isNotGeneric = C == dynamic;
+  final bool _supportsPropertyChanges = C is PropertyChangeRecord;
 
   /// Emits a list of changes when the state of the object changes.
   ///
@@ -80,17 +80,15 @@ abstract class Observable<C extends ChangeRecord> {
     /*=T*/
     newValue,
   ) {
-    if (hasObservers && oldValue != newValue) {
-      if (_isNotGeneric) {
-        notifyChange(
-          new PropertyChangeRecord(
-            this,
-            field,
-            oldValue,
-            newValue,
-          ) as C,
-        );
-      }
+    if (hasObservers && oldValue != newValue && _supportsPropertyChanges) {
+      notifyChange(
+        new PropertyChangeRecord(
+          this,
+          field,
+          oldValue,
+          newValue,
+        ) as C,
+      );
     }
     return newValue;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.18.0
+version: 0.18.1
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
There are classes of `class Type<T> extends Object with Observable<T>`.

This triggered an `UnsupportedError` in `Observable.notifyChange` - had to make an internal patch ignoring this exception until this is landed.