### PR TITLE
bug(ObservableMap): Avoid no-op MapChangeRecord

### DIFF
--- a/lib/src/collections/observable_map.dart
+++ b/lib/src/collections/observable_map.dart
@@ -107,6 +107,9 @@ class _ObservableDelegatingMap<K, V> extends DelegatingMap<K, V>
 
   @override
   void notifyChange([ChangeRecord change]) {
+    if (change is MapChangeRecord && change.oldValue == change.newValue) {
+      return;  
+    }
     _allChanges.notifyChange(change);
   }
 

--- a/lib/src/collections/observable_map.dart
+++ b/lib/src/collections/observable_map.dart
@@ -108,7 +108,7 @@ class _ObservableDelegatingMap<K, V> extends DelegatingMap<K, V>
   @override
   void notifyChange([ChangeRecord change]) {
     if (change is MapChangeRecord && change.oldValue == change.newValue) {
-      return;  
+      return;
     }
     _allChanges.notifyChange(change);
   }


### PR DESCRIPTION
i.e., `notifyChange(new MapChangeRecord(this, 'key', 'someValue', 'someValue'))`.

Was needed to land the previous version internally.