### PR TITLE
Patch observable list to restore discardListChanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.2
+
+* Bug fix: Avoid emitting a no-op `MapChangeRecord`
+* Bug fix: Restore `ObservableList.discardListChanges` functionality
+
 ## 0.20.1
 
 * Add `Observable<List|Set|Map>.unmodifiable` for immutable collections

--- a/lib/src/change_notifier.dart
+++ b/lib/src/change_notifier.dart
@@ -10,6 +10,11 @@ import 'internal.dart';
 import 'observable.dart';
 import 'records.dart';
 
+// Temporarily exists to keep 'discard changes' API working for now.
+void internalDiscardChanges(ChangeNotifier changeNotifier) {
+  changeNotifier._queue = null;
+}
+
 /// Supplies [changes] and various hooks to implement [Observable].
 ///
 /// May use [notifyChange] to queue a change record; they are asynchronously

--- a/lib/src/collections/observable_list.dart
+++ b/lib/src/collections/observable_list.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:observable/observable.dart';
+import 'package:observable/src/change_notifier.dart';
 import 'package:observable/src/differs.dart';
 
 /// A [List] that broadcasts [changes] to subscribers for efficient mutations.
@@ -167,7 +168,7 @@ class _ObservableDelegatingList<E> extends DelegatingList<E>
 
   @override
   void discardListChanges() {
-    // This used to do something, but now we just make it a no-op.
+    internalDiscardChanges(_listChanges);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.20.1
+version: 0.20.2
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
There are a few occurrences internally that are non-trivial to fix while landing updates.

Also bump pubspec to `0.20.2` for release, containing two bug fixes:

## 0.20.2

* Bug fix: Avoid emitting a no-op `MapChangeRecord`
* Bug fix: Restore `ObservableList.discardListChanges` functionality
