### PR TITLE
Fix bug, tidy up.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.3
+
+* Bug fix: Avoid emitting an empty list via `ObservableList.listChanges`
+
 ## 0.20.2
 
 * Bug fix: Avoid emitting a no-op `MapChangeRecord`

--- a/lib/src/collections/observable_list.dart
+++ b/lib/src/collections/observable_list.dart
@@ -216,11 +216,9 @@ class _ObservableDelegatingList<E> extends DelegatingList<E>
   bool get hasListObservers => _listChanges.hasObservers;
 
   @override
-  Stream<List<ListChangeRecord<E>>> get listChanges {
-    return _listChanges.changes
-        .map((r) => projectListSplices(this, r))
-        .where((c) => c.isNotEmpty);
-  }
+  Stream<List<ListChangeRecord<E>>> get listChanges => _listChanges.changes
+      .map((r) => projectListSplices(this, r))
+      .where((c) => c.isNotEmpty);
 
   @override
   void notifyListChange(

--- a/lib/src/collections/observable_list.dart
+++ b/lib/src/collections/observable_list.dart
@@ -217,7 +217,9 @@ class _ObservableDelegatingList<E> extends DelegatingList<E>
 
   @override
   Stream<List<ListChangeRecord<E>>> get listChanges {
-    return _listChanges.changes.map((r) => projectListSplices(this, r));
+    return _listChanges.changes
+        .map((r) => projectListSplices(this, r))
+        .where((c) => c.isNotEmpty);
   }
 
   @override

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -53,8 +53,6 @@ abstract class Observable<C extends ChangeRecord> {
   ///
   /// Returns `true` if changes were emitted.
   @Deprecated('Use ChangeNotifier instead to have this method available')
-  // REMOVE IGNORE when https://github.com/dart-lang/observable/issues/10
-  // ignore: invalid_use_of_protected_member
   bool deliverChanges() => _delegate.deliverChanges();
 
   /// Notify that the [field] name of this object has been changed.

--- a/tool/presubmit.sh
+++ b/tool/presubmit.sh
@@ -26,13 +26,18 @@ echo "PASSED"
 # Fail on anything that fails going forward.
 set -e
 
+# Allow running this script locally, otherwise it fails outside of travis.
+if [[ ${TEST_PLATFORM} == "" ]]
+then
+  TEST_PLATFORM="vm"
+fi
+
 THE_COMMAND="pub run test -p $TEST_PLATFORM"
-if [ $TEST_PLATFORM == 'firefox' ]; then
+if [[ ${TEST_PLATFORM} == "firefox" ]]
+then
   export DISPLAY=:99.0
   sh -e /etc/init.d/xvfb start
   t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done
 fi
 echo $THE_COMMAND
 exec $THE_COMMAND
-
-pub run test


### PR DESCRIPTION
## 0.20.3

* Bug fix: Avoid emitting an empty list via `ObservableList.listChanges`

Closes https://github.com/dart-lang/observable/issues/27, which was hot-fixed internally.

---

Also adds a few test cases for `listChanges` and restores running `travis.sh` locally.
