### PR TITLE
Avoid emitting ChangeRecord.ANY in listChanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.4
+
+* Bug fix: Additional fix around `ObservableList.listChanges`
+
 ## 0.20.3
 
 * Bug fix: Avoid emitting an empty list via `ObservableList.listChanges`

--- a/lib/src/collections/observable_list.dart
+++ b/lib/src/collections/observable_list.dart
@@ -216,9 +216,11 @@ class _ObservableDelegatingList<E> extends DelegatingList<E>
   bool get hasListObservers => _listChanges.hasObservers;
 
   @override
-  Stream<List<ListChangeRecord<E>>> get listChanges => _listChanges.changes
-      .map((r) => projectListSplices(this, r))
-      .where((c) => c.isNotEmpty);
+  Stream<List<ListChangeRecord<E>>> get listChanges {
+    return _listChanges.changes
+        .map((r) => projectListSplices(this, r))
+        .where((r) => r.isNotEmpty && r != ChangeRecord.ANY);
+  }
 
   @override
   void notifyListChange(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.20.2
+version: 0.20.4
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
This was already patched internally.

Closes https://github.com/dart-lang/observable/issues/29