### PR TITLE
Don't use generic types in constant expressions.

### DIFF
--- a/lib/src/collections/observable_set.dart
+++ b/lib/src/collections/observable_set.dart
@@ -156,7 +156,7 @@ class _UnmodifiableEmptySet<E> extends IterableBase<E> implements Set<E> {
   Set<E> intersection(Set<Object> other) => this;
 
   @override
-  Iterator<E> get iterator => const <E>[].iterator;
+  Iterator<E> get iterator => const <Null>[].iterator;
 
   @override
   E lookup(Object object) => null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: observable
-version: 0.20.4
+version: 0.20.5
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=1.22.0 <2.0.0'
 dependencies:
   collection: '^1.11.0'
   meta: '^1.0.4'


### PR DESCRIPTION
Constant expressions are not allowed to use generic types in Dart 1.

Fixes issue #31.