### PR TITLE
Fix some types where DDC expects more strictness:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## 0.20.4+2
 
-* Some minor type fixes for strict runtimes (and Dart 2.0), namely:
+* Support the latest release of `pkg/quiver` (0.26).
+* Bug fix: Some minor type fixes for strict runtimes (and Dart 2.0), namely:
   * PropertyChangeNotifier merely `extends
     ChangeNotifier` rather than `extends ChangeNotifier<PropertyChangeRecord>`.
   * Introduce new `ListChangeRecord.NONE` and `MapChangeRecord.NONE`.
 
 ## 0.20.4+1
 
-* Support the latest release of `pkg/quiver`.
+* Support the latest release of `pkg/quiver` (0.25).
 
 ## 0.20.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.20.4+2
+
+* Some minor type fixes for strict runtimes (and Dart 2.0), namely:
+  * PropertyChangeNotifier merely `extends
+    ChangeNotifier` rather than `extends ChangeNotifier<PropertyChangeRecord>`.
+  * Introduce new `ListChangeRecord.NONE` and `MapChangeRecord.NONE`.
+
 ## 0.20.4+1
 
 * Support the latest release of `pkg/quiver`.

--- a/lib/src/change_notifier.dart
+++ b/lib/src/change_notifier.dart
@@ -119,7 +119,7 @@ class ChangeNotifier<C extends ChangeRecord> implements Observable<C> {
 /// [PropertyChangeNotifier] may be extended or used as a delegate. To use as
 /// a mixin, instead use with [PropertyChangeMixin]:
 ///     with ChangeNotifier<PropertyChangeRecord>, PropertyChangeMixin
-class PropertyChangeNotifier extends ChangeNotifier<PropertyChangeRecord> {
+class PropertyChangeNotifier extends ChangeNotifier {
   @override
   T notifyPropertyChange<T>(
     Symbol field,

--- a/lib/src/differs/list_differ.dart
+++ b/lib/src/differs/list_differ.dart
@@ -206,7 +206,7 @@ List<ListChangeRecord<E>> _calcSplices<E>(
   oldEnd -= suffixCount;
 
   if (currentEnd - currentStart == 0 && oldEnd - oldStart == 0) {
-    return ChangeRecord.NONE;
+    return ListChangeRecord.NONE;
   }
 
   if (currentStart == currentEnd) {

--- a/lib/src/differs/map_differ.dart
+++ b/lib/src/differs/map_differ.dart
@@ -17,7 +17,7 @@ class MapDiffer<K, V> implements Differ<Map<K, V>> {
   @override
   List<MapChangeRecord<K, V>> diff(Map<K, V> oldValue, Map<K, V> newValue) {
     if (identical(oldValue, newValue)) {
-      return ChangeRecord.NONE;
+      return MapChangeRecord.NONE;
     }
     final changes = <MapChangeRecord<K, V>>[];
     oldValue.forEach((oldK, oldV) {

--- a/lib/src/records/list_change_record.dart
+++ b/lib/src/records/list_change_record.dart
@@ -12,6 +12,9 @@ part of observable.src.records;
 /// the final list positions to figure out which item was added - this removes
 /// the need to incur costly GC on the most common operation (adding).
 class ListChangeRecord<E> implements ChangeRecord {
+  /// Signifies no changes occurred.
+  static const NONE = const <ListChangeRecord>[];
+
   /// How many elements were added at [index] (after removing elements).
   final int addedCount;
 

--- a/lib/src/records/map_change_record.dart
+++ b/lib/src/records/map_change_record.dart
@@ -6,6 +6,9 @@ part of observable.src.records;
 
 /// A [ChangeRecord] that denotes adding, removing, or updating a map.
 class MapChangeRecord<K, V> implements ChangeRecord {
+  /// Signifies no changes occurred.
+  static const NONE = const <MapChangeRecord>[];
+
   /// The map key that changed.
   final K key;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.20.4+1
+version: 0.20.4+2
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable

--- a/test/differs/map_differ_test.dart
+++ b/test/differs/map_differ_test.dart
@@ -13,7 +13,7 @@ main() {
       final map = new Map<String, String>.fromIterable(
         new Iterable.generate(10, (i) => '$i'),
       );
-      expect(diff(map, map), ChangeRecord.NONE);
+      expect(diff(map, map), MapChangeRecord.NONE);
     });
 
     test('should emit no changes for maps with identical content', () {
@@ -23,7 +23,7 @@ main() {
       final map2 = new Map<String, String>.fromIterable(
         new Iterable.generate(10, (i) => '$i'),
       );
-      expect(diff(map1, map2), ChangeRecord.NONE);
+      expect(diff(map1, map2), MapChangeRecord.NONE);
     });
 
     test('should detect insertions', () {


### PR DESCRIPTION
* `ChangeRecord.NONE` creates a `List<ChangeRecord>`, while the call sites
  expect a `List<ListChangeRecord>` or `List<MapChangeRecord>`, respectively.