### PR TITLE
Expand the quiver version constraints

### DIFF
--- a/lib/src/records.dart
+++ b/lib/src/records.dart
@@ -5,7 +5,7 @@
 library observable.src.records;
 
 import 'package:collection/collection.dart';
-import 'package:quiver/core.dart';
+import 'package:quiver/core.dart' as quiver;
 
 import 'internal.dart';
 

--- a/lib/src/records/list_change_record.dart
+++ b/lib/src/records/list_change_record.dart
@@ -120,7 +120,8 @@ class ListChangeRecord<E> implements ChangeRecord {
 
   @override
   int get hashCode {
-    return hash4(object, index, addedCount, const ListEquality().hash(removed));
+    return quiver.hash4(
+        object, index, addedCount, const ListEquality().hash(removed));
   }
 
   @override

--- a/lib/src/records/map_change_record.dart
+++ b/lib/src/records/map_change_record.dart
@@ -65,7 +65,7 @@ class MapChangeRecord<K, V> implements ChangeRecord {
 
   @override
   int get hashCode {
-    return hashObjects([
+    return quiver.hashObjects([
       key,
       oldValue,
       newValue,

--- a/lib/src/records/property_change_record.dart
+++ b/lib/src/records/property_change_record.dart
@@ -37,7 +37,7 @@ class PropertyChangeRecord<T> implements ChangeRecord {
   }
 
   @override
-  int get hashCode => hash4(object, name, oldValue, newValue);
+  int get hashCode => quiver.hash4(object, name, oldValue, newValue);
 
   @override
   String toString() => ''

--- a/lib/src/records/set_change_record.dart
+++ b/lib/src/records/set_change_record.dart
@@ -32,7 +32,7 @@ class SetChangeRecord<E> implements ChangeRecord {
       o is SetChangeRecord<E> && element == o.element && isRemove == o.isRemove;
 
   @override
-  int get hashCode => hash2(element, isRemove);
+  int get hashCode => quiver.hash2(element, isRemove);
 
   @override
   String toString() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,6 @@ environment:
 dependencies:
   collection: '^1.11.0'
   meta: '^1.0.4'
-  quiver: '>=0.24.0 <0.26.0'
+  quiver: '>=0.24.0 <0.27.0'
 dev_dependencies:
   test: '^0.12.17'


### PR DESCRIPTION
I also change quiver's import namespace, so that it is clear where the top-level methods come from.

Fixes #42 