### PR TITLE
Self-execute closures for assert()

### DIFF
--- a/lib/src/differs/list_differ.dart
+++ b/lib/src/differs/list_differ.dart
@@ -306,7 +306,7 @@ List<ListChangeRecord<E>> _calcSplices<E>(
   assert(() {
     splices = new List<ListChangeRecord<E>>.unmodifiable(splices);
     return true;
-  });
+  }());
   return splices;
 }
 

--- a/lib/src/internal.dart
+++ b/lib/src/internal.dart
@@ -7,6 +7,6 @@ List<E> freezeInDevMode<E>(List<E> list) {
   assert(() {
     list = new List<E>.unmodifiable(list);
     return true;
-  });
+  }());
   return list;
 }

--- a/lib/src/records/list_change_record.dart
+++ b/lib/src/records/list_change_record.dart
@@ -95,7 +95,7 @@ class ListChangeRecord<E> implements ChangeRecord {
         throw new ArgumentError('Invalid `addedCount`: $addedCount');
       }
       return true;
-    });
+    }());
   }
 
   /// Returns whether [reference] index was changed in this operation.


### PR DESCRIPTION
The dart language will soon stop accepting closures into assert: https://github.com/dart-lang/sdk/issues/30326

This PR changes the asserts in observable to self-execute it's closures, so that a mere `bool` is passed to `assert()`.