### PR TITLE
Changes for landing https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ Revert considered deprecated to be notified of `length`, `isEmpty` and
 * Removed `Observable{List|Map}.NONE` (not Dart2 compatible).
 * Fix issue with type in `ObservableList._notifyListChange`. cl/182284033
 
+## 0.21.0+1-dev
+
+* Updated one of observable's tests to comply with dart 2 voidness semantics
+
 ## 0.20.4+3
 
 * Support the latest release of `pkg/quiver` (0.27).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.21.0
+version: 0.21.0+1-dev
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable

--- a/test/observable_test.dart
+++ b/test/observable_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 import 'observable_test_utils.dart';
 
-main() => observableTests();
+void main() => observableTests();
 
 void observableTests() {
   // Track the subscriptions so we can clean them up in tearDown.


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which may be illegal in dart 2, but in either case, expresses
the current intent better.