### PR TITLE
Remove visibleForTesting annotation from ChangeNotifier.deliverChanges.

### DIFF
--- a/lib/src/change_notifier.dart
+++ b/lib/src/change_notifier.dart
@@ -49,7 +49,6 @@ class ChangeNotifier<C extends ChangeRecord> implements Observable<C> {
   ///
   /// Returns `true` if changes were emitted.
   @override
-  @visibleForTesting
   @mustCallSuper
   bool deliverChanges() {
     List<ChangeRecord> changes;


### PR DESCRIPTION
It is used in `lib/src/observable.dart`.