### PR TITLE
Fix runtime cast failures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Files and directories created by pub
+.dart_tool/
 .packages
 .pub/
 packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 dart:
   - dev
-  - 2.0.0-dev.12.0
+  - 2.0.0-dev.23.0
 addons:
   # otherwise a number of tests in test/security/html_sanitizer_test.dart fail
   firefox: "latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: dart
 sudo: false
 dart:
-  - stable
   - dev
-  - 1.23.0
+  - 2.0.0-dev.12.0
 addons:
   # otherwise a number of tests in test/security/html_sanitizer_test.dart fail
   firefox: "latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 0.21.0+1-dev
+## 0.21.1-dev
 
-* Updated one of observable's tests to comply with dart 2 voidness semantics
+* Updated one test to comply with Dart 2 voidness semantics.
+* Fix Dart 2 runtime cast failure in `toObservable()`.
+* Loosen `ObservableList.from()` to take `Iterable`, not `Iterable<T>`. This
+  matches `List.from()` and avoids some unnecessary cast failures.
 
 ## 0.21.0
 

--- a/lib/src/observable_list.dart
+++ b/lib/src/observable_list.dart
@@ -42,8 +42,7 @@ class ObservableList<E> extends ListBase<E> with Observable {
 
   /// Creates an observable list with the elements of [other]. The order in
   /// the list will be the order provided by the iterator of [other].
-  factory ObservableList.from(Iterable<E> other) =>
-      new ObservableList<E>()..addAll(other);
+  ObservableList.from(Iterable other) : _list = new List<E>.from(other);
 
   /// The stream of summarized list changes, delivered asynchronously.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=2.0.0-dev.12.0 <2.0.0'
 dependencies:
   collection: '^1.11.0'
   dart_internal: '^0.1.1'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.21.0+1-dev
+version: 0.21.1-dev
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable
@@ -7,6 +7,7 @@ environment:
   sdk: '>=1.23.0 <2.0.0'
 dependencies:
   collection: '^1.11.0'
+  dart_internal: '^0.1.1'
   meta: '^1.0.4'
   quiver: '>=0.24.0 <0.29.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable
 environment:
-  sdk: '>=2.0.0-dev.12.0 <2.0.0'
+  sdk: '>=2.0.0-dev.23.0 <2.0.0'
 dependencies:
   collection: '^1.11.0'
   dart_internal: '^0.1.1'


### PR DESCRIPTION
In strong mode, a generic type instantiated with dynamic is not a
subtype of all types. You can't pass a List<dynamic> to something
expecting, say, List<int>.

These errors are usually detected statically, and most of those have
been fixed. However, sometimes this becomes a runtime cast, as in:

    main() {
      // Store a List<dynamic> in a variable of type dynamic.
      dynamic d = [];

      // Implicit runtime downcast from dynamic to List<String>.
      List<String> s = d;
    }

In order to ease the migration to strong mode, DDC has been ignoring
these cast failures when they involve certain commonly used types. We
are now in the process of actively fixing those errors.

More context: https://github.com/dart-lang/sdk/issues/27223