### PR TITLE
Stop using Maps class before it is deleted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.1+1-dev
+
+* Remove use of `Maps`, for better compatibility with Dart 2.
+
 ## 0.21.1
 
 * Updated one test to comply with Dart 2 voidness semantics.

--- a/lib/src/observable_map.dart
+++ b/lib/src/observable_map.dart
@@ -152,7 +152,7 @@ class ObservableMap<K, V> extends Observable implements Map<K, V> {
   void forEach(void f(K key, V value)) => _map.forEach(f);
 
   @override
-  String toString() => Maps.mapToString(this);
+  String toString() => MapBase.mapToString(this);
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observable
-version: 0.21.1
+version: 0.21.1+1-dev
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable


### PR DESCRIPTION
The Maps class will be deleted in Dart 2. The `Maps.mapToString()` method was copied to MapBase in Dart 2.0.0-dev.22.0, which is below the minimum SDK version for this package.