### PR TITLE
Honor `deep: false` when converting Maps.

### DIFF
--- a/lib/src/to_observable.dart
+++ b/lib/src/to_observable.dart
@@ -34,13 +34,8 @@ dynamic _toObservableShallow(dynamic value) {
   if (value is Observable) return value;
 
   if (value is Map) {
-    return extractMapTypeArguments(value, <K, V>() {
-      var result = new ObservableMap<K, V>.createFromType(value);
-      value.forEach((k, v) {
-        result[_toObservableDeep(k)] = _toObservableDeep(v);
-      });
-      return result;
-    });
+    return extractMapTypeArguments(
+        value, <K, V>() => new ObservableMap<K, V>.from(value));
   }
 
   if (value is Iterable) {


### PR DESCRIPTION
Currently toObservable always converts maps deeply.