### PR TITLE
Update implementations of the `cast` and the deprecated `retype` methods.

### DIFF
--- a/lib/src/observable_list.dart
+++ b/lib/src/observable_list.dart
@@ -60,9 +60,7 @@ class ObservableList<E> extends ListBase<E> with Observable {
 
   ObservableList._spy(List<E> other) : _list = other;
 
-  /// Returns a view of this list as a list of [T] instances, if necessary.
-  ///
-  /// If this list is already a `ObservableList<T>`, it is returned unchanged.
+  /// Returns a view of this list as a list of [T] instances.
   ///
   /// If this list contains only instances of [T], all read operations
   /// will work correctly. If any operation tries to access an element
@@ -73,12 +71,7 @@ class ObservableList<E> extends ListBase<E> with Observable {
   /// and they must be instances of [E] as well to be accepted by
   /// this list as well.
   @override
-  ObservableList<T> cast<T>() {
-    if (this is ObservableList<T>) {
-      return this as ObservableList<T>;
-    }
-    return retype<T>();
-  }
+  ObservableList<T> cast<T>() => ObservableList.castFrom<E, T>(this);
 
   /// Returns a view of this list as a list of [T] instances.
   ///
@@ -91,7 +84,8 @@ class ObservableList<E> extends ListBase<E> with Observable {
   /// and they must be instances of [E] as well to be accepted by
   /// this list as well.
   @override
-  ObservableList<T> retype<T>() => ObservableList.castFrom<E, T>(this);
+  // ignore: override_on_non_overriding_method
+  ObservableList<T> retype<T>() => cast<T>();
 
   /// The stream of summarized list changes, delivered asynchronously.
   ///

--- a/lib/src/observable_map.dart
+++ b/lib/src/observable_map.dart
@@ -174,13 +174,11 @@ class ObservableMap<K, V> extends Observable implements Map<K, V> {
 
   @override
   ObservableMap<K2, V2> cast<K2, V2>() {
-    if (this is ObservableMap<K2, V2>) {
-      return this as ObservableMap<K2, V2>;
-    }
     return ObservableMap.castFrom<K, V, K2, V2>(this);
   }
 
   @override
+  // ignore: override_on_non_overriding_method
   ObservableMap<K2, V2> retype<K2, V2>() {
     return ObservableMap.castFrom<K, V, K2, V2>(this);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: observable
-version: 0.22.1+2
+version: 0.22.1+3
 author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/dart-lang/observable
 environment:
-  sdk: '>=2.0.0-dev.23.0 <2.0.0'
+  sdk: '>=2.0.0-dev.55.0 <2.0.0'
 dependencies:
   collection: '^1.11.0'
   dart_internal: '^0.1.1'


### PR DESCRIPTION
The `retype` method on `List` and `Map` is deprecated and will be removed.
The `cast` method should do what the `retype` method did.

This updates the `cast` and `retype` methods and prepares `retype` for being removed from the interface.