### PR TITLE
Deprecate `retype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.1+3
+
+Update implementations of the `cast()` and the deprecated `retype()` methods.
+* The `retype()` method on List and Map is deprecated and will be removed.
+* The `cast()` method should do what the `retype()` method did.
+
 ## 0.22.1+2
 
 * Widen dependency on quiver to include v0.29.

--- a/lib/src/observable_list.dart
+++ b/lib/src/observable_list.dart
@@ -83,6 +83,7 @@ class ObservableList<E> extends ListBase<E> with Observable {
   /// must be instance of [T] to be valid arguments to the adding function,
   /// and they must be instances of [E] as well to be accepted by
   /// this list as well.
+  @deprecated
   @override
   // ignore: override_on_non_overriding_method
   ObservableList<T> retype<T>() => cast<T>();

--- a/lib/src/observable_map.dart
+++ b/lib/src/observable_map.dart
@@ -177,6 +177,7 @@ class ObservableMap<K, V> extends Observable implements Map<K, V> {
     return ObservableMap.castFrom<K, V, K2, V2>(this);
   }
 
+  @deprecated
   @override
   // ignore: override_on_non_overriding_method
   ObservableMap<K2, V2> retype<K2, V2>() {


### PR DESCRIPTION
Update CHANGELOG in preparation to publish