### PR TITLE
Remove unneeded dart:async import

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -4,8 +4,6 @@
 
 library observable.src.observable;
 
-import 'dart:async';
-
 import 'package:meta/meta.dart';
 
 import 'change_notifier.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Support for marking objects as observable
 homepage: https://github.com/google/observable
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   collection: ^1.11.0


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core.

Alternatively, if for some reason this package needs to continue to
support Dart 2.0, an exception can be made for this internally.